### PR TITLE
fix: correct a bunch of typos on the SSR example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ For more optimized SSR usage, you'll want to pre-fetch the tweet AST data server
 
 ```tsx
 import React from 'react'
-import [ fetchTweetAst } from 'static-tweets'
+import { fetchTweetAst } from 'static-tweets'
 import { Tweet } from 'react-static-tweets'
 
 const tweetId = '1358199505280262150'
@@ -66,7 +66,7 @@ export const getStaticProps = async () => {
   }
 }
 
-export default Example({ tweetId, tweetAst }) => {
+export default function Example({ tweetId, tweetAst }) {
   return <Tweet id={tweetId} ast={tweetAst} />
 }
 ```


### PR DESCRIPTION
Fixes a few typos on the SSR example on `readme.md`:
Corrects the typo `[` => `{`.
Corrects the mixed syntax on default export.
