### PR TITLE
Update tweet HTML tag and add forwardRef

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@
 .vercel/
 build/
 docs/
+node_modules/
+lerna.json

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "run-s start",
     "pretest": "run-s build",
     "test": "run-s test:*",
-    "test:prettier": "prettier '**/*.{js,jsx,json,ts,tsx}' --check",
+    "test:prettier": "prettier '**/*.{js,jsx,json,ts,tsx}' --check --config ./.prettierrc",
     "docs": "run-s docs:extract docs:generate",
     "docs:extract": "lerna exec --ignore react-static-tweets --ignore react-static-tweets-example api-extractor run",
     "docs:generate": "api-documenter markdown -i build -o docs",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "run-s start",
     "pretest": "run-s build",
     "test": "run-s test:*",
-    "test:prettier": "prettier '**/*.{js,jsx,json,ts,tsx}' --check --config ./.prettierrc",
+    "test:prettier": "prettier '**/*.{js,jsx,json,ts,tsx}' --check",
     "docs": "run-s docs:extract docs:generate",
     "docs:extract": "lerna exec --ignore react-static-tweets --ignore react-static-tweets-example api-extractor run",
     "docs:generate": "api-documenter markdown -i build -o docs",

--- a/packages/react-static-tweets/src/tweet.tsx
+++ b/packages/react-static-tweets/src/tweet.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import cs from 'classnames'
 import useSWR from 'swr'
 
@@ -6,32 +6,38 @@ import { useTwitterContext } from './twitter'
 import Node from './html/node'
 import components from './twitter-layout/components'
 
-export const Tweet: React.FC<{
+type TweetProps = {
   id: string
   ast?: any
   caption?: string
   className?: string
   // TODO: understand what br is used for
   // br?: string
-}> = ({ id, ast, caption, className }) => {
-  const twitter = useTwitterContext()
-  const { data: tweetAst } = useSWR(
-    id,
-    (id) => ast || twitter.tweetAstMap[id] || twitter.swrOptions.fetcher(id),
-    twitter.swrOptions
-  )
-
-  return (
-    <main className={cs('static-tweet', className)}>
-      {tweetAst && (
-        <>
-          <Node components={components} node={tweetAst[0]} />
-
-          {caption != null ? (
-            <p className='static-tweet-caption'>{caption}</p>
-          ) : null}
-        </>
-      )}
-    </main>
-  )
 }
+
+const Tweet = forwardRef<HTMLElement, TweetProps>(
+  ({ id, ast, caption, className }: TweetProps, ref) => {
+    const twitter = useTwitterContext()
+    const { data: tweetAst } = useSWR(
+      id,
+      (id) => ast || twitter.tweetAstMap[id] || twitter.swrOptions.fetcher(id),
+      twitter.swrOptions
+    )
+
+    return (
+      <article ref={ref} className={cs('static-tweet', className)}>
+        {tweetAst && (
+          <>
+            <Node components={components} node={tweetAst[0]} />
+
+            {caption != null ? (
+              <p className='static-tweet-caption'>{caption}</p>
+            ) : null}
+          </>
+        )}
+      </article>
+    )
+  }
+)
+
+export { Tweet }


### PR DESCRIPTION
# Summary

This PR updates the root HTML tag of Tweet to be semantically correct and adds `forwardRef` to Tweet.

# Motivation

- There can only be one `main` element on any one page according to the HTML spec: https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element. That makes rendering multiple tweets hard if some automated HTML validation audit runs on your builds. In our case, this was reported by the aXe developer tools audit as erroneous markup.
- Adding `forwardRef` makes it possible to pass a ref in order to get a reference to the rendered DOM element, if needed.

# Detailed design

I replaced the root `main` tag in `packages/react-static-tweets/src/tweet.tsx` with an `article` tag. According to MDN:

> The HTML <article> element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). 

A tweet seems to fit that description.

I also wrapped a `forwardRef` around `<Tweet />`. As a type for the ref, I passed in `HTMLElement`, because there is no dedicated type for `article`.