### PR TITLE
fix: support webpack@5

### DIFF
--- a/packages/react-static-tweets/package.json
+++ b/packages/react-static-tweets/package.json
@@ -9,6 +9,9 @@
   "module": "build/esm/index.js",
   "typings": "build/esm/index.d.ts",
   "type": "commonjs",
+  "sideEffects": [
+    "*.css"
+  ],
   "exports": {
     "import": "./build/esm/index.js",
     "default": "./build/cjs/index.js"


### PR DESCRIPTION
# Summary

This change in the `package.json` makes sure that `next` doesn't error with the below when using `webpack5: true` in `next.config.js`.

```sh
Module not found: Package path ./styles.css is not exported from package <project_folder>/node_modules/react-static-tweets (see exports field in <project_folder>/node_modules/react-static-tweets/package.json)
> 1 | import 'react-static-tweets/styles.css';
```