### PR TITLE
Better style encapsulation

### DIFF
--- a/packages/react-static-tweets/styles.css
+++ b/packages/react-static-tweets/styles.css
@@ -35,6 +35,12 @@
   --tweet-color-red: #e02460;
 }
 
+/* reset all styles to avoid leaks */
+.static-tweet,
+.static-tweet * {
+  all: initial;
+}
+
 .static-tweet {
   width: 100%;
   max-width: 550px;


### PR DESCRIPTION
Done:

- Added CSS reset (`all: initial`) to `.static-tweet` and all children.

Untested, pls help me out @transitive-bullshit, check your DMs :)

Other ideas:

- [ ] Make parent class more specific, for example: `static-tweet` => `__static_tweet__`
- [ ] Change selectors to depend on the parent class, for example: `.static-tweet-anchor` => `.static-tweet .anchor`
- [ ] CSS modules? (I don't really think it adds much value but it's an option)