### PR TITLE
fix: webpack 5 support

### DIFF
--- a/packages/react-static-tweets/package.json
+++ b/packages/react-static-tweets/package.json
@@ -2,20 +2,24 @@
   "name": "react-static-tweets",
   "version": "0.4.0",
   "description": "Extremely fast static renderer for tweets.",
-  "repository": "transitive-bullshit/react-static-tweets",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/transitive-bullshit/react-static-tweets.git",
+    "directory": "packages/react-static-tweets"
+  },
   "author": "Travis Fischer <travis@transitivebullsh.it>",
   "license": "MIT",
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "typings": "build/esm/index.d.ts",
-  "type": "commonjs",
   "sideEffects": [
     "*.css"
   ],
-  "exports": {
-    "import": "./build/esm/index.js",
-    "default": "./build/cjs/index.js"
-  },
+  "files": [
+    "readme.md",
+    "build",
+    "styles.css"
+  ],
   "engines": {
     "node": ">=12"
   },
@@ -29,13 +33,13 @@
     "@types/react-dom": "^17.0.0",
     "date-fns": "^2.17.0",
     "next": "^10.0.6",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "peerDependencies": {
     "date-fns": ">=2",
     "next": "^10.0.6",
-    "react": ">=16",
-    "react-dom": ">=16"
+    "react": "^16.8.0 || 17.x",
+    "react-dom": "^16.8.0 || 17.x"
   }
 }

--- a/packages/react-static-tweets/tsconfig.json
+++ b/packages/react-static-tweets/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "src",
     "outDir": "build/esm",
     "tsBuildInfoFile": "build/esm/index.tsbuildinfo",
-    "lib": ["DOM"],
+    "lib": ["DOM", "ESNext"],
     "strict": false,
     "noImplicitReturns": false,
     "skipLibCheck": true,

--- a/packages/static-tweets/package.json
+++ b/packages/static-tweets/package.json
@@ -2,7 +2,11 @@
   "name": "static-tweets",
   "version": "0.4.0",
   "description": "Utilities for fetching and manipulating tweet ASTs.",
-  "repository": "transitive-bullshit/react-static-tweets",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/transitive-bullshit/react-static-tweets.git",
+    "directory": "packages/static-tweets"
+  },
   "author": "Travis Fischer <travis@transitivebullsh.it>",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "moduleResolution": "node"
   },
   "files": [],
   "include": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6870,14 +6870,14 @@ rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
-  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "^0.20.1"
+    scheduler "^0.20.2"
 
 react-is@16.13.1, react-is@^16.8.1:
   version "16.13.1"
@@ -6889,10 +6889,10 @@ react-refresh@0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -7355,10 +7355,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
-  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
# Summary

In the last PR I made to enable Webpack 5 support in Next.js for this package, it worked for a bit locally, but when installing the package through `npm` the change I made was broken.

I've tested this implementation a bit more thoroughly now and this should now work when using enabling webpack 5 in your `next.config.js`.