### PR TITLE
Make a new entry point for Next.js only

### DIFF
--- a/packages/react-static-tweets/package.json
+++ b/packages/react-static-tweets/package.json
@@ -27,5 +27,10 @@
     "next": "^10.0.6",
     "react": ">=16",
     "react-dom": ">=16"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": true
+    }
   }
 }

--- a/packages/react-static-tweets/src/next.tsx
+++ b/packages/react-static-tweets/src/next.tsx
@@ -1,0 +1,43 @@
+import React, { forwardRef } from 'react'
+import cs from 'classnames'
+import useSWR from 'swr'
+
+import { useTwitterContext } from './twitter'
+import Node from './html/node'
+import components from './twitter-layout/components/next'
+
+type TweetProps = {
+  id: string
+  ast?: any
+  caption?: string
+  className?: string
+  // TODO: understand what br is used for
+  // br?: string
+}
+
+const Tweet = forwardRef<HTMLElement, TweetProps>(
+  ({ id, ast, caption, className }: TweetProps, ref) => {
+    const twitter = useTwitterContext()
+    const { data: tweetAst } = useSWR(
+      id,
+      (id) => ast || twitter.tweetAstMap[id] || twitter.swrOptions.fetcher(id),
+      twitter.swrOptions
+    )
+
+    return (
+      <article ref={ref} className={cs('static-tweet', className)}>
+        {tweetAst && (
+          <>
+            <Node components={components} node={tweetAst[0]} />
+
+            {caption != null ? (
+              <p className='static-tweet-caption'>{caption}</p>
+            ) : null}
+          </>
+        )}
+      </article>
+    )
+  }
+)
+
+export { Tweet }

--- a/packages/react-static-tweets/src/twitter-layout/components/media.next.tsx
+++ b/packages/react-static-tweets/src/twitter-layout/components/media.next.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+// import dynamic from 'next/dynamic' // TODO
+import Image from 'next/image'
 import { useTweet } from './tweet/tweet'
 
 export const Img = ({ width, height, src, ...p }) => {
@@ -19,7 +21,13 @@ export const Img = ({ width, height, src, ...p }) => {
           target='_blank'
           rel='noopener noreferrer'
         >
-          <img {...p} src={`${src}&name=small`} />
+          <Image
+            {...p}
+            src={`${src}&name=small`}
+            layout='fill'
+            objectFit='cover'
+            quality={80}
+          />
         </a>
       </summary>
     </details>

--- a/packages/react-static-tweets/src/twitter-layout/components/media.tsx
+++ b/packages/react-static-tweets/src/twitter-layout/components/media.tsx
@@ -19,7 +19,7 @@ export const Img = ({ width, height, src, ...p }) => {
           target='_blank'
           rel='noopener noreferrer'
         >
-          <img {...p} src={`${src}&name=small`} />
+          <img {...p} className='bare' src={`${src}&name=small`} />
         </a>
       </summary>
     </details>

--- a/packages/react-static-tweets/src/twitter-layout/components/next.ts
+++ b/packages/react-static-tweets/src/twitter-layout/components/next.ts
@@ -1,0 +1,50 @@
+import { Div } from './containers'
+import { H1, H2, H3, H4, H5, H6 } from './headings'
+import { P, Blockquote, Hr } from './text'
+import { Code, Pre } from './code'
+import { A } from './anchor'
+import { Ul, Ol, Li } from './lists'
+import { Table, Th, Td } from './table'
+import { Img } from './media.next'
+import { Mention, Hashtag, Cashtag, Emoji, Poll } from './twitter'
+import Tweet from './tweet/tweet'
+import EmbeddedTweet from './embedded-tweet'
+
+export default {
+  div: Div,
+
+  h1: H1,
+  h2: H2,
+  h3: H3,
+  h4: H4,
+  h5: H5,
+  h6: H6,
+
+  p: P,
+  blockquote: Blockquote,
+  hr: Hr,
+
+  code: Code,
+  pre: Pre,
+
+  a: A,
+
+  ul: Ul,
+  ol: Ol,
+  li: Li,
+
+  table: Table,
+  th: Th,
+  td: Td,
+
+  img: Img,
+
+  Mention,
+  Hashtag,
+  Cashtag,
+  Emoji,
+  Poll,
+
+  Tweet,
+  EmbeddedTweet
+}

--- a/packages/react-static-tweets/styles.css
+++ b/packages/react-static-tweets/styles.css
@@ -213,6 +213,10 @@
   display: none;
 }
 
+.static-tweet-summary img.bare {
+  object-fit: cover;
+}
+
 .static-tweet-table-container {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Hi!

I just wanted to use this package really but I found that this package is tied to Next.js directly as discussed in #2.

This PR makes the `<Img>` component to simple img tag with optional `react-static-tweets/next` entry point that allows to use Next.js image optimization as usual.

**This PR is a breaking change.**